### PR TITLE
feat(frontend): 实现路由守卫进行权限控制

### DIFF
--- a/frontend/text2image-vue/src/router/index.js
+++ b/frontend/text2image-vue/src/router/index.js
@@ -1,7 +1,8 @@
 import Vue from 'vue';
 import VueRouter from 'vue-router';
-import RegisterView from '@/views/RegisterView.vue';
-import LoginView from '@/views/LoginView.vue';
+import {
+    Message
+} from 'element-ui'; // 导入 Message 组件
 import AboutView from '@/views/AboutView.vue';
 
 
@@ -10,62 +11,88 @@ import AboutView from '@/views/AboutView.vue';
 Vue.use(VueRouter)
 
 const routes = [{
-    path: '/',
-    redirect: '/about',
-}, {
-    path: '/about',
-    name: 'about',
-    component: AboutView
-}, {
-    path: '/register',
-    name: 'register',
-    component: RegisterView
-}, {
-    path: '/login',
-    name: 'login',
-    component: LoginView
-}, {
-    path: '/main',
-    name: 'main',
-    redirect: '/main/explore',
-    component: () =>
-        import ('@/views/InnerView.vue'),
-    children: [{
-        path: 'generate',
-        name: 'generate',
-        component: () =>
-            import ('@/views/GenerateView.vue')
+        path: '/',
+        redirect: '/about',
     }, {
-        path: 'history',
-        name: 'history',
+        path: '/about',
+        name: 'about',
+        component: AboutView
+    },
+    //{
+    //     path: '/register',
+    //     name: 'register',
+    //     component: RegisterView
+    // }, {
+    //     path: '/login',
+    //     name: 'login',
+    //     component: LoginView
+    // },
+    {
+        path: '/main',
+        name: 'main',
+        meta: {
+            requiresAuth: true
+        },
+        redirect: '/main/explore',
         component: () =>
-            import ('@/views/HistoryView.vue')
+            import ('@/views/InnerView.vue'),
+        children: [{
+            path: 'generate',
+            name: 'generate',
+            component: () =>
+                import ('@/views/GenerateView.vue')
+        }, {
+            path: 'history',
+            name: 'history',
+            component: () =>
+                import ('@/views/HistoryView.vue')
+        }, {
+            path: 'explore',
+            name: 'explore',
+            component: () =>
+                import ('@/views/ExploreView.vue')
+        }, {
+            path: 'favorites',
+            name: 'favorites',
+            component: () =>
+                import ('@/views/FavoritesView.vue')
+        }, {
+            path: 'setting',
+            name: 'setting',
+            component: () =>
+                import ('@/views/SettingView.vue')
+        }]
     }, {
-        path: 'explore',
-        name: 'explore',
+        path: '/log-reg',
         component: () =>
-            import ('@/views/ExploreView.vue')
-    }, {
-        path: 'favorites',
-        name: 'favorites',
-        component: () =>
-            import ('@/views/FavoritesView.vue')
-    }, {
-        path: 'setting',
-        name: 'setting',
-        component: () =>
-            import ('@/views/SettingView.vue')
-    }]
-}, {
-    path: '/log-reg',
-    component: () =>
-        import ('@/views/LogRegView.vue')
-}]
+            import ('@/views/LogRegView.vue')
+    }
+]
 
 const router = new VueRouter({
     mode: 'history',
     base: process.env.BASE_URL,
     routes
 })
+router.beforeEach((to, from, next) => {
+    const requiresAuth = to.matched.some(record => record.meta.requiresAuth);
 
+    if (requiresAuth) {
+        // 检查 localStorage 中是否有 token
+        const token = localStorage.getItem('token');
+
+        // 如果有 token，则允许访问
+        if (token) {
+            next();
+        } else {
+            // 如果没有 token，则重定向到登录页面
+            Message.error('您还未登录，请先登录!'); // 使用 Message 组件
+            next({
+                path: '/log-reg',
+            });
+        }
+    } else {
+        next(); // 不需要认证的路由直接放行
+    }
+});
 export default router


### PR DESCRIPTION
- 添加了 router.beforeEach 守卫，对需要认证的路由进行检查
- 引入了 element-ui 的 Message 组件用于提示信息
- 修改了路由配置，增加了对认证路由的 meta 标记
- 优化了路由结构，合并了重复的路径配置