### PR TITLE
feat(frontend): 优化点赞功能并添加生成历史记录

### DIFF
--- a/frontend/text2image-vue/src/views/GenerateView.vue
+++ b/frontend/text2image-vue/src/views/GenerateView.vue
@@ -160,7 +160,15 @@ export default {
         // 更新图片 URL
         const lastIdx = this.temp_generatedImg_results.length - 1;
         this.$set(this.temp_generatedImg_results[lastIdx], 'img_url', imageUrl);
-
+         // 发送历史记录请求
+    await this.$axios.post('http://localhost:8080/auth/generate/addhistory', {
+      prompt: this.form.prompt,
+      width: this.form.width,
+      height: this.form.height,
+      seed: this.form.seed,
+      steps: this.form.steps,
+      pictureURL: imageUrl
+    });
         this.$message.success('图片上传成功');
       } catch (error) {
         console.error('Error uploading image:', error);


### PR DESCRIPTION
- 修改 ExploreView 中的 likeImage 方法，使其通过图像 ID 进行操作
- 添加错误处理，确保在点赞失败时恢复图像的 isliked 状态
- 在 GenerateView 中添加发送生成历史记录的请求